### PR TITLE
Use frameworks for CocoaPods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,2 +1,4 @@
+use_frameworks!
+
 pod "GCDWebServer", "~> 3.0"
 


### PR DESCRIPTION
It's required to support latest swift and xcode version.
It's the fix for https://github.com/tapthaker/FBSimulatorClient/issues/1
